### PR TITLE
Fix error

### DIFF
--- a/hawk/routes/catcher/php.js
+++ b/hawk/routes/catcher/php.js
@@ -6,7 +6,7 @@ let Crypto = require('crypto');
 let project = require('../../models/project');
 
 let md5 = function (input) {
-  return Crypto.createHash('md5').update(input, 'utf8').digest('hex');
+  return Crypto.createHash('md5').update(input.toString(), 'utf8').digest('hex');
 };
 
 /**


### PR DESCRIPTION
```shell
TypeError: Data must be a string or a buffer
    at TypeError (native)
    at Hash.update (crypto.js:74:16)
    at md5 (/var/www/hawk.so/hawk/routes/catcher/php.js:9:35)
    at getServerErrors (/var/www/hawk.so/hawk/routes/catcher/php.js:87:16)
    at Layer.handle [as handle_request] (/var/www/hawk.so/hawk/node_modules/express/lib/router/layer.js:95:5)
    at next (/var/www/hawk.so/hawk/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/var/www/hawk.so/hawk/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/var/www/hawk.so/hawk/node_modules/express/lib/router/layer.js:95:5)
    at /var/www/hawk.so/hawk/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/var/www/hawk.so/hawk/node_modules/express/lib/router/index.js:335:12)```